### PR TITLE
logging: Fix compilation errors with clang++ when printing void*

### DIFF
--- a/include/zephyr/logging/log_msg.h
+++ b/include/zephyr/logging/log_msg.h
@@ -560,7 +560,7 @@ do { \
 
 /* Create local variable from input variable (expect for the first (fmt) argument). */
 #define Z_LOG_LOCAL_ARG_CREATE(idx, arg) \
-	COND_CODE_0(idx, (), (Z_AUTO_TYPE Z_LOG_LOCAL_ARG_NAME(idx, arg) = (arg) + 0))
+	COND_CODE_0(idx, (), (Z_AUTO_TYPE Z_LOG_LOCAL_ARG_NAME(idx, arg) = 0?(arg):(arg)))
 
 /* First level of processing creates stack variables to be passed for further processing.
  * This is done to prevent multiple evaluations of input arguments (in case argument


### PR DESCRIPTION
https://docs.zephyrproject.org/latest/services/logging/index.html#recommendations recommends to cast arguments logged with %p to void *, and it works fine with gcc, g++ and clang. however with clang++ it causes error that cannot be suppressed: error: arithmetic on a pointer to void.

It is because we are using (arg) + 0 inside _Generic to workaround issues with _Generic and bit fields. https://gcc.gnu.org/legacy-ml/gcc/2016-02/msg00266.html suggests to use different syntax: 0:(arg):(arg). This seems to be working with gcc, g++, clang and clang++

Fixes: #87308

Signed-off-by: Maciej Kusio <rysiof@gmail.com>